### PR TITLE
Rework `bindings!` and `actions!` macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `bindings!` now properly works with trailing commas and no longer requires wrapping single elements in braces when mixed with tuples.
+
 ## [0.15.3] - 2025-08-07
 
 ### Added

--- a/src/action/relationship.rs
+++ b/src/action/relationship.rs
@@ -68,24 +68,18 @@ pub type ActionSpawnerCommands<'w, C> = RelatedSpawnerCommands<'w, ActionOf<C>>;
 ///
 /// # Examples
 ///
-/// List of single elements. You usually spawn actions with at least [`Bindings`](crate::prelude::Bindings),
+/// A List of context actions with a component. You usually spawn actions with at least [`Bindings`](crate::prelude::Bindings),
 /// but actions alone could be used for networking or for later mocking.
 ///
 /// ```
 /// # use bevy::prelude::*;
 /// # use bevy_enhanced_input::prelude::*;
-/// # use core::any;
-/// let from_macro = actions!(Player[
+/// # let mut world = World::new();
+/// world.spawn(actions!(Player[
 ///     Action::<Fire>::new(),
 ///     Action::<Jump>::new()
-/// ]);
-/// // Expands to the following:
-/// let manual = Actions::<Player>::spawn((
-///     Spawn(Action::<Fire>::new()),
-///     Spawn(Action::<Jump>::new()),
-/// ));
-///
-/// assert_eq!(any::type_name_of_val(&from_macro), any::type_name_of_val(&manual));
+/// ]));
+/// # assert_eq!(world.entities().len(), 3);
 /// # #[derive(Component)]
 /// # struct Player;
 /// # #[derive(InputAction)]
@@ -96,26 +90,41 @@ pub type ActionSpawnerCommands<'w, C> = RelatedSpawnerCommands<'w, ActionOf<C>>;
 /// # struct Jump;
 /// ```
 ///
-/// With tuples.
+/// A single context action with components.
 ///
 /// ```
 /// # use bevy::prelude::*;
 /// # use bevy_enhanced_input::prelude::*;
-/// # use core::any;
-/// let from_macro = actions!(Player[
+/// # let mut world = World::new();
+/// world.spawn(actions!(Player[(
+///     Action::<Fire>::new(),
+///     bindings![MouseButton::Left],
+/// )]));
+/// # assert_eq!(world.entities().len(), 3);
+/// # #[derive(Component)]
+/// # struct Player;
+/// # #[derive(InputAction)]
+/// # #[action_output(bool)]
+/// # struct Fire;
+/// ```
+///
+/// A List of context actions with multiple components.
+///
+/// ```
+/// # use bevy::prelude::*;
+/// # use bevy_enhanced_input::prelude::*;
+/// # let mut world = World::new();
+/// world.spawn(actions!(Player[
 ///     (
 ///         Action::<Move>::new(),
-///         Bindings::spawn(Cardinal::wasd_keys())
+///         Bindings::spawn(Cardinal::wasd_keys()),
 ///     ),
-///     Action::<Jump>::new(), // Unlike with `bindings!`, single values could be mixed with tuples.
-/// ]);
-/// // Expands to the following:
-/// let manual = Actions::<Player>::spawn((
-///     Spawn((Action::<Move>::new(), Bindings::spawn(Cardinal::wasd_keys()))),
-///     Spawn(Action::<Jump>::new()),
-/// ));
-///
-/// assert_eq!(any::type_name_of_val(&from_macro), any::type_name_of_val(&manual));
+///     (
+///         Action::<Jump>::new(),
+///         bindings![KeyCode::Space],
+///     ),
+/// ]));
+/// # assert_eq!(world.entities().len(), 8);
 /// # #[derive(Component)]
 /// # struct Player;
 /// # #[derive(InputAction)]

--- a/src/action/relationship.rs
+++ b/src/action/relationship.rs
@@ -137,6 +137,6 @@ pub type ActionSpawnerCommands<'w, C> = RelatedSpawnerCommands<'w, ActionOf<C>>;
 #[macro_export]
 macro_rules! actions {
     ($context:ty [$($action:expr),*$(,)?]) => {
-       $crate::prelude::Actions::<$context>::spawn(($(::bevy::prelude::Spawn($action)),*))
+        ::bevy::prelude::related!($crate::prelude::Actions<$context>[$($action),*])
     };
 }

--- a/src/binding/relationship.rs
+++ b/src/binding/relationship.rs
@@ -100,11 +100,11 @@ macro_rules! bindings {
     };
 }
 
-/// Types that can be converted into a bundle with a [`Binding`].
+/// Types that can be converted into a bundle whose first element can be converted into a [`Binding`].
 ///
 /// Used to avoid writing [`Binding::from`] inside [`bindings!`].
 pub trait IntoBindingBundle {
-    /// Returns a bundle.
+    /// Returns a bundle with a binding.
     fn into_binding_bundle(self) -> impl Bundle;
 }
 

--- a/src/binding/relationship.rs
+++ b/src/binding/relationship.rs
@@ -94,7 +94,7 @@ pub type BindingSpawnerCommands<'w> = RelatedSpawnerCommands<'w, BindingOf>;
 #[macro_export]
 macro_rules! bindings {
     [$($binding:expr),*$(,)?] => {
-        $crate::prelude::Bindings::spawn(($(::bevy::prelude::Spawn($crate::prelude::IntoBindingBundle::into_binding_bundle($binding))),*))
+        ::bevy::prelude::related!($crate::prelude::Bindings[$($crate::prelude::IntoBindingBundle::into_binding_bundle($binding)),*])
     };
 }
 

--- a/src/binding/relationship.rs
+++ b/src/binding/relationship.rs
@@ -7,6 +7,8 @@ use bevy::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::prelude::*;
+
 /// Action entity associated with this binding entity.
 ///
 /// See also the [`bindings!`](crate::prelude::bindings) macro for conveniently spawning associated actions.
@@ -97,8 +99,6 @@ macro_rules! bindings {
         ::bevy::prelude::related!($crate::prelude::Bindings[$($crate::prelude::IntoBindingBundle::into_binding_bundle($binding)),*])
     };
 }
-
-use crate::prelude::*;
 
 /// Types that can be converted into a bundle with a [`Binding`].
 ///

--- a/src/binding/relationship.rs
+++ b/src/binding/relationship.rs
@@ -104,7 +104,7 @@ macro_rules! bindings {
 ///
 /// Used to avoid writing [`Binding::from`] inside [`bindings!`].
 pub trait IntoBindingBundle {
-    /// Returns a bundle with a binding.
+    /// Returns a bundle for a binding.
     fn into_binding_bundle(self) -> impl Bundle;
 }
 

--- a/src/binding/relationship.rs
+++ b/src/binding/relationship.rs
@@ -46,62 +46,84 @@ pub type BindingSpawnerCommands<'w> = RelatedSpawnerCommands<'w, BindingOf>;
 /// The macro accepts either individual elements that implement [`Into<Binding>`], or tuples where the first element implements
 /// [`Into<Binding>`] and the remaining elements are bundles.
 ///
-/// Due to `macro_rules!` limitations, you can't mix tuples and individual elements. However, you can wrap individual elements in braces
-/// to use them alongside tuples.
-///
 /// The macro can't be used to spawn [presets](crate::preset). See the module documentation for more details.
 ///
 /// See also [`actions!`](crate::prelude::actions).
 ///
 /// # Examples
 ///
-/// List of single elements.
+/// A list of action bindings with components constructed from values that implement [`Into<Binding>`].
 ///
 /// ```
 /// # use bevy::prelude::*;
 /// # use bevy_enhanced_input::prelude::*;
-/// # use core::any;
-/// let from_macro = bindings![KeyCode::Space, GamepadButton::South];
-/// // Expands to the following:
-/// let manual = Bindings::spawn((
-///     Spawn(Binding::from(KeyCode::Space)),
-///     Spawn(Binding::from(GamepadButton::South)),
-/// ));
-///
-/// assert_eq!(any::type_name_of_val(&from_macro), any::type_name_of_val(&manual));
+/// # let mut world = World::new();
+/// world.spawn(bindings![KeyCode::Space, GamepadButton::South]);
+/// # assert_eq!(world.entities().len(), 3);
 /// ```
 ///
-/// List of tuples.
+/// A single action binding with the first component constructed from a value implementing [`Into<Binding>`],
+/// and the rest as regular components.
 ///
 /// ```
 /// # use bevy::prelude::*;
 /// # use bevy_enhanced_input::prelude::*;
-/// # use core::any;
-/// let from_macro = bindings![
+/// # let mut world = World::new();
+/// world.spawn(bindings![(
+///     GamepadButton::RightTrigger2,
+///     Down::new(0.3),
+/// )]);
+/// # assert_eq!(world.entities().len(), 2);
+/// ```
+///
+/// A list of action bindings with the first component constructed from a value implementing [`Into<Binding>`],
+/// and the rest as regular components.
+///
+/// ```
+/// # use bevy::prelude::*;
+/// # use bevy_enhanced_input::prelude::*;
+/// # let mut world = World::new();
+/// world.spawn(bindings![
 ///     (GamepadButton::RightTrigger2, Down::new(0.3)),
-///     (MouseButton::Left), // Necessary to wrap in braces since we use a tuple above.
-/// ];
-/// // Expands to the following:
-/// let manual = Bindings::spawn((
-///     Spawn((Binding::from(GamepadButton::RightTrigger2), Down::new(0.3))),
-///     Spawn((Binding::from(MouseButton::Left),)), // Extra braces could be omitted here, but necessary for the check below.
-/// ));
-///
-/// assert_eq!(any::type_name_of_val(&from_macro), any::type_name_of_val(&manual));
+///     MouseButton::Left,
+/// ]);
+/// # assert_eq!(world.entities().len(), 3);
 /// ```
 ///
 /// [`SpawnableList`]: bevy::ecs::spawn::SpawnableList
 #[macro_export]
 macro_rules! bindings {
-    [ $( ( $first:expr $(, $rest:expr )* ) ),* $(,)? ] => {
-        $crate::prelude::Bindings::spawn((
-            $( ::bevy::prelude::Spawn(($crate::prelude::Binding::from($first), $($rest),*)) ),*
-        ))
-    };
-
-    [ $( $binding:expr ),* $(,)? ] => {
-        $crate::prelude::Bindings::spawn((
-            $( ::bevy::prelude::Spawn($crate::prelude::Binding::from($binding)) ),*
-        ))
+    [$($binding:expr),*$(,)?] => {
+        $crate::prelude::Bindings::spawn(($(::bevy::prelude::Spawn($crate::prelude::IntoBindingBundle::into_binding_bundle($binding))),*))
     };
 }
+
+use crate::prelude::*;
+
+/// Types that can be converted into a bundle with a [`Binding`].
+///
+/// Used to avoid writing [`Binding::from`] inside [`bindings!`].
+pub trait IntoBindingBundle {
+    /// Returns a bundle.
+    fn into_binding_bundle(self) -> impl Bundle;
+}
+
+impl<B: Into<Binding>> IntoBindingBundle for B {
+    fn into_binding_bundle(self) -> impl Bundle {
+        self.into()
+    }
+}
+
+macro_rules! impl_into_binding_bundle {
+    ($($C:ident),*) => {
+        impl<B: Into<Binding>, $($C: Bundle,)*> IntoBindingBundle for (B, $($C),*) {
+            #[allow(non_snake_case, reason = "tuple unpack")]
+            fn into_binding_bundle(self) -> impl Bundle {
+                let (b, $($C),* ) = self;
+                (b.into(), $($C),*)
+            }
+        }
+    }
+}
+
+variadics_please::all_tuples!(impl_into_binding_bundle, 0, 14, C);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,10 +126,10 @@ world.spawn((
                 (KeyCode::KeyW, SwizzleAxis::YXZ),
                 (KeyCode::KeyA, Negate::all()),
                 (KeyCode::KeyS, Negate::all(), SwizzleAxis::YXZ),
-                (KeyCode::KeyD),
+                KeyCode::KeyD,
                 // In Bevy sticks split by axes and captured as 1-dimensional inputs,
                 // so Y stick needs to be sweezled into Y axis.
-                (GamepadAxis::LeftStickX),
+                GamepadAxis::LeftStickX,
                 (GamepadAxis::LeftStickY, SwizzleAxis::YXZ),
             ]
         ),
@@ -211,7 +211,7 @@ world.spawn((
             Pulse::new(0.5), // The action will trigger every 0.5 seconds while held.
             bindings![
                 (GamepadButton::RightTrigger2, Down::new(0.3)), // Additionally the right trigger only counts if its value is greater than 0.3.
-                (MouseButton::Left),
+                MouseButton::Left,
             ]
         ),
     ])
@@ -399,7 +399,9 @@ pub mod prelude {
         binding::{
             Binding, InputModKeys,
             mod_keys::ModKeys,
-            relationship::{BindingOf, BindingSpawner, BindingSpawnerCommands, Bindings},
+            relationship::{
+                BindingOf, BindingSpawner, BindingSpawnerCommands, Bindings, IntoBindingBundle,
+            },
         },
         bindings,
         condition::{


### PR DESCRIPTION
It's impossible to properly express "convert first element into Binding" with a `macro_rules`. But I realized that we can just move some of the things into a type system. This way it properly works with trailing commas and no longer requires wrapping single elements in braces when mixed with tuples.