### PR TITLE
Remove `DeadZone::with_lower_threshold` and

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- `DeadZone::with_lower_threshold` and `DeadZone::with_upper_threshold`. All fields are public, just use struct initialization syntax.
+
 ## [0.15.3] - 2025-08-07
 
 ### Added

--- a/src/modifier/dead_zone.rs
+++ b/src/modifier/dead_zone.rs
@@ -39,18 +39,6 @@ impl DeadZone {
         }
     }
 
-    #[must_use]
-    pub const fn with_lower_threshold(mut self, lower_threshold: f32) -> Self {
-        self.lower_threshold = lower_threshold;
-        self
-    }
-
-    #[must_use]
-    pub const fn with_upper_threshold(mut self, upper_threshold: f32) -> Self {
-        self.upper_threshold = upper_threshold;
-        self
-    }
-
     fn dead_zone(self, axis_value: f32) -> f32 {
         // Translate and scale the input to the +/- 1 range after removing the dead zone.
         let lower_bound = (axis_value.abs() - self.lower_threshold).max(0.0);


### PR DESCRIPTION
`DeadZone::with_upper_threshold`

Cart generally prefers not to have these because they're annoying to maintain, bloat compile times, and offer a second way to do things that isn't much better. They're also not BSN compatible.

This makes sense when all fields are public. In our case, it's only `DeadZone`.

There are a few other places, but they have private fields. For those, I think convenience methods are justified, since we can't initialize them using struct initialization syntax, so there is no API duplication.

@alice-i-cecile feel free to suggest more things like this.