### PR TITLE
Add context activation/deactivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ContextActivity<C>` component to activate or deactivate context `C`.
+
 ### Changed
 
 - `bindings!` now properly works with trailing commas and no longer requires wrapping single elements in braces when mixed with tuples.

--- a/examples/context_switch.rs
+++ b/examples/context_switch.rs
@@ -31,28 +31,10 @@ fn attack(_trigger: Trigger<Fired<Attack>>) {
 
 fn open_inventory(trigger: Trigger<Started<OpenInventory>>, mut commands: Commands) {
     info!("opening inventory");
-    commands
-        .entity(trigger.target())
-        .remove_with_requires::<Player>() // Necessary to fully remove the context.
-        .despawn_related::<Actions<Player>>()
-        .insert((
-            Inventory,
-            actions!(Inventory[
-                (
-                    Action::<NavigateInventory>::new(),
-                    Bindings::spawn((Cardinal::wasd_keys(), Axial::left_stick())),
-                    Pulse::new(0.2), // Avoid triggering every frame on hold for UI.
-                ),
-                (
-                    Action::<CloseInventory>::new(),
-                    ActionSettings {
-                        require_reset: true,
-                        ..Default::default()
-                    },
-                    bindings![KeyCode::KeyI, GamepadButton::Select],
-                )
-            ]),
-        ));
+    commands.entity(trigger.target()).insert((
+        ContextActivity::<Player>::INACTIVE,
+        ContextActivity::<Inventory>::ACTIVE,
+    ));
 }
 
 fn navigate_inventory(_trigger: Trigger<Fired<NavigateInventory>>) {
@@ -61,11 +43,10 @@ fn navigate_inventory(_trigger: Trigger<Fired<NavigateInventory>>) {
 
 fn close_inventory(trigger: Trigger<Started<CloseInventory>>, mut commands: Commands) {
     info!("closing inventory");
-    commands
-        .entity(trigger.target())
-        .remove_with_requires::<Inventory>()
-        .despawn_related::<Actions<Inventory>>()
-        .insert(player_bundle());
+    commands.entity(trigger.target()).insert((
+        ContextActivity::<Player>::ACTIVE,
+        ContextActivity::<Inventory>::INACTIVE,
+    ));
 }
 
 fn player_bundle() -> impl Bundle {
@@ -91,6 +72,22 @@ fn player_bundle() -> impl Bundle {
                 },
                 bindings![KeyCode::KeyI, GamepadButton::Select],
             ),
+        ]),
+        Inventory,
+        actions!(Inventory[
+            (
+                Action::<NavigateInventory>::new(),
+                Bindings::spawn((Cardinal::wasd_keys(), Axial::left_stick())),
+                Pulse::new(0.2), // Avoid triggering every frame on hold for UI.
+            ),
+            (
+                Action::<CloseInventory>::new(),
+                ActionSettings {
+                    require_reset: true,
+                    ..Default::default()
+                },
+                bindings![KeyCode::KeyI, GamepadButton::Select],
+            )
         ]),
     )
 }

--- a/src/action.rs
+++ b/src/action.rs
@@ -190,7 +190,7 @@ pub struct ActionSettings {
     pub accumulation: Accumulation,
 
     /// Require inputs to be inactive before the first activation and continue to consume them
-    /// even after context removal until inputs become inactive again.
+    /// even after context removal or deactivation until inputs become inactive again.
     ///
     /// This way new instances won't react to currently held inputs until they are released.
     /// This prevents unintended behavior where switching or layering contexts using the same key

--- a/src/context.rs
+++ b/src/context.rs
@@ -582,7 +582,7 @@ fn apply<S: ScheduleLabel>(
 #[component(immutable)]
 pub struct ContextActivity<C> {
     #[deref]
-    value: bool,
+    active: bool,
     #[reflect(ignore)]
     marker: PhantomData<C>,
 }
@@ -596,9 +596,9 @@ impl<C> ContextActivity<C> {
 
     /// Creates a new instance with the given value.
     #[must_use]
-    pub const fn new(value: bool) -> Self {
+    pub const fn new(active: bool) -> Self {
         Self {
-            value,
+            active,
             marker: PhantomData,
         }
     }
@@ -606,7 +606,7 @@ impl<C> ContextActivity<C> {
     /// Returns a new instance with the value inverted.
     #[must_use]
     pub const fn toggled(self) -> Self {
-        if self.value {
+        if self.active {
             Self::INACTIVE
         } else {
             Self::ACTIVE

--- a/src/context.rs
+++ b/src/context.rs
@@ -564,7 +564,7 @@ fn apply<S: ScheduleLabel>(
     }
 }
 
-/// Enables or disables all context action updates from inputs and mocks.
+/// Enables or disables all action updates from inputs and mocks for context `C`.
 ///
 /// By default, all contexts are active.
 ///
@@ -574,8 +574,8 @@ fn apply<S: ScheduleLabel>(
 /// to be inactive before they will be visible to actions from other contexts.
 ///
 /// This is analogous to hiding an entity instead of despawning.
-/// Disable when you want to toggle quickly, preserve bindings, or keep entity IDs.
-/// Remove when the context is truly going away and you don't need it back soon.
+/// Use this component when you want to toggle quickly, preserve bindings, or keep entity IDs.
+/// Use removal when the context is truly going away and you don't need it back soon.
 ///
 /// Marked as required for `C` on context registration.
 #[derive(Component, Reflect, Deref)]

--- a/src/context/instance.rs
+++ b/src/context/instance.rs
@@ -12,7 +12,7 @@ use bevy::{
     prelude::*,
 };
 
-use crate::prelude::*;
+use crate::{context::ContextActivity, prelude::*};
 
 /// Stores information about instantiated contexts for a schedule `S`.
 ///
@@ -57,6 +57,7 @@ pub(crate) struct ContextInstance {
     pub(super) name: &'static str,
     type_id: TypeId,
     priority: usize,
+    is_active: fn(&Self, &FilteredEntityRef) -> bool,
     actions: for<'a> fn(&Self, &'a FilteredEntityRef) -> Option<&'a [Entity]>,
     actions_mut: for<'a> fn(&Self, &'a mut FilteredEntityMut) -> Option<&'a mut [Entity]>,
 }
@@ -70,9 +71,15 @@ impl ContextInstance {
             name: any::type_name::<C>(),
             type_id: TypeId::of::<C>(),
             priority,
+            is_active: Self::is_active_typed::<C>,
             actions: Self::actions_typed::<C>,
             actions_mut: Self::actions_mut_typed::<C>,
         }
+    }
+
+    /// Returns the value from [`ContextActivity<C>`].
+    pub(super) fn is_active(&self, context: &FilteredEntityRef) -> bool {
+        (self.is_active)(self, context)
     }
 
     /// Returns a reference to entities from [`Actions<C>`], for which this instance was created.
@@ -88,6 +95,12 @@ impl ContextInstance {
         context: &'a mut FilteredEntityMut,
     ) -> Option<&'a mut [Entity]> {
         (self.actions_mut)(self, context)
+    }
+
+    pub(super) fn is_active_typed<C: Component>(&self, context: &FilteredEntityRef) -> bool {
+        context
+            .get::<ContextActivity<C>>()
+            .is_some_and(|&active| *active)
     }
 
     fn actions_typed<'a, C: Component>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,7 @@ context entity.
 
 Context actions will be evaluated in the schedule associated at context registration. Contexts registered in the same
 schedule will be evaluated in their spawning order, but you can override it by adding the [`ContextPriority`] component.
+You can also activate or deactivate contexts by inserting [`ContextActivity`] component.
 
 Actions also have [`ActionSettings`] component that customizes their behavior.
 
@@ -349,6 +350,9 @@ Actions aren't despawned automatically via [`EntityWorldMut::remove_with_require
 despawn related entities when their relationship targets (like [`Actions<C>`]) are removed. For this reason, [`Actions<C>`]
 is not a required component for `C`. See [this issue](https://github.com/bevyengine/bevy/issues/20252) for more details.
 
+When an action is despawned, it automatically transitions its state to [`ActionState::None`] with [`ActionValue::zero`],
+triggering the corresponding events. Depending on your use case, using [`ContextActivity`] might be more convenient than removal.
+
 ## Input and UI
 
 Currently, we don't integrate `bevy_input_focus` directly. But we provide [`ActionSources`] resource
@@ -410,7 +414,7 @@ pub mod prelude {
             release::*, tap::*,
         },
         context::{
-            ActionsQuery, ContextPriority, GamepadDevice, InputContextAppExt,
+            ActionsQuery, ContextActivity, ContextPriority, GamepadDevice, InputContextAppExt,
             input_reader::ActionSources,
             time::{ContextTime, TimeKind},
         },


### PR DESCRIPTION
Sometimes it's useful to temporarily deactivate a context without removing it. This PR introduces `ContextActivity` component, which is similar to Bevy's `Visibility`.

I split changes into 2 logical commits: first the actual implementation and the second one updates `context_swtich` example to use it.