### PR TITLE
Rename preset helper methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `bindings!` now properly works with trailing commas and no longer requires wrapping single elements in braces when mixed with tuples.
 - `Clone`, `PartialEq`, `Eq` and `Debug` are implemented for `ActionOf<C>` even if `C` doesn't implement them.
+- Rename `Bidirectional::horizontal_arrow_keys` into `Bidirectional::arrow_x_keys`.
+- Rename `Bidirectional::vertical_arrow_keys` into `Bidirectional::arrow_y_keys`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `ContextActivity<C>` component to activate or deactivate context `C`.
-- `Bidirectional::dpad_x_buttons` and `Bidirectional::dpad_y_buttons`.
+- `Bidirectional::left_right_dpad` and `Bidirectional::up_down_dpad`.
 
 ### Changed
 
@@ -18,8 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Clone`, `PartialEq`, `Eq` and `Debug` are implemented for `ActionOf<C>` even if `C` doesn't implement them.
 - Don't trigger change detection on `Actions<C>` on sorting if it's already sorted.
 - `InputAction` now requires `PartialEq`, and `Action<A>` implements `PartialEq`.
-- Rename `Bidirectional::horizontal_arrow_keys` into `Bidirectional::arrow_x_keys`.
-- Rename `Bidirectional::vertical_arrow_keys` into `Bidirectional::arrow_y_keys`.
+- Rename `Bidirectional::horizontal_arrow_keys` into `Bidirectional::left_right_arrows`.
+- Rename `Bidirectional::vertical_arrow_keys` into `Bidirectional::up_down_arrows`.
+- Rename `Cardinal::arrow_keys` into `Cardinal::arrows`.
+- Rename `Cardinal::dpad_buttons` into `Cardinal::dpad`.
+- Rename `Ordinal::numpad_keys` into `Cardinal::numpad`.
 
 ### Removed
 

--- a/examples/character_controller.rs
+++ b/examples/character_controller.rs
@@ -46,7 +46,7 @@ fn setup(
                 Scale::splat(450.0),
                 Bindings::spawn((
                     Bidirectional::ad_keys(),
-                    Bidirectional::horizontal_arrow_keys(),
+                    Bidirectional::arrow_x_keys(),
                     Axial::left_stick(),
                 )),
             ),

--- a/examples/character_controller.rs
+++ b/examples/character_controller.rs
@@ -46,7 +46,7 @@ fn setup(
                 Scale::splat(450.0),
                 Bindings::spawn((
                     Bidirectional::ad_keys(),
-                    Bidirectional::arrow_x_keys(),
+                    Bidirectional::left_right_arrow(),
                     Axial::left_stick(),
                 )),
             ),

--- a/examples/local_multiplayer.rs
+++ b/examples/local_multiplayer.rs
@@ -115,7 +115,7 @@ fn player_bundle(
     // Assign different bindings based on the player index.
     let move_bindings = match player {
         Player::First => Bindings::spawn((Cardinal::wasd_keys(), Axial::left_stick())),
-        Player::Second => Bindings::spawn((Cardinal::arrow_keys(), Axial::left_stick())),
+        Player::Second => Bindings::spawn((Cardinal::arrows(), Axial::left_stick())),
     };
 
     (

--- a/examples/simple_fly_cam.rs
+++ b/examples/simple_fly_cam.rs
@@ -65,7 +65,7 @@ fn setup(
                     // In Bevy, vertical scrolling maps to the Y axis,
                     // so we apply `SwizzleAxis` to map it to our 1-dimensional action.
                     Spawn((Binding::mouse_wheel(), SwizzleAxis::YXZ)),
-                    Bidirectional::dpad_y_buttons(),
+                    Bidirectional::up_down_dpad(),
                 )),
             ),
             // For bindings we also have a macro similar to `children!`.

--- a/src/preset/bidirectional.rs
+++ b/src/preset/bidirectional.rs
@@ -52,7 +52,7 @@ impl Bidirectional<Binding, Binding> {
 
     /// Maps left and right keyboard arrow keys as 1-dimensional input.
     #[must_use]
-    pub fn horizontal_arrow_keys() -> Self {
+    pub fn arrow_x_keys() -> Self {
         Self {
             positive: KeyCode::ArrowRight.into(),
             negative: KeyCode::ArrowLeft.into(),
@@ -61,7 +61,7 @@ impl Bidirectional<Binding, Binding> {
 
     /// Maps up and down keyboard arrow keys as 1-dimensional input.
     #[must_use]
-    pub fn vertical_arrow_keys() -> Self {
+    pub fn arrow_y_keys() -> Self {
         Self {
             positive: KeyCode::ArrowRight.into(),
             negative: KeyCode::ArrowLeft.into(),

--- a/src/preset/bidirectional.rs
+++ b/src/preset/bidirectional.rs
@@ -52,7 +52,7 @@ impl Bidirectional<Binding, Binding> {
 
     /// Maps left and right keyboard arrow keys as 1-dimensional input.
     #[must_use]
-    pub fn arrow_x_keys() -> Self {
+    pub fn left_right_arrow() -> Self {
         Self {
             positive: KeyCode::ArrowRight.into(),
             negative: KeyCode::ArrowLeft.into(),
@@ -61,7 +61,7 @@ impl Bidirectional<Binding, Binding> {
 
     /// Maps up and down keyboard arrow keys as 1-dimensional input.
     #[must_use]
-    pub fn arrow_y_keys() -> Self {
+    pub fn up_down_arrow() -> Self {
         Self {
             positive: KeyCode::ArrowRight.into(),
             negative: KeyCode::ArrowLeft.into(),
@@ -70,7 +70,7 @@ impl Bidirectional<Binding, Binding> {
 
     /// Maps up and down D-pad buttons as 1-dimensional horizontal input.
     #[must_use]
-    pub fn dpad_x_buttons() -> Self {
+    pub fn left_right_dpad() -> Self {
         Self {
             positive: GamepadButton::DPadRight.into(),
             negative: GamepadButton::DPadLeft.into(),
@@ -79,7 +79,7 @@ impl Bidirectional<Binding, Binding> {
 
     /// Maps left and right D-pad buttons as 1-dimensional horizontal input.
     #[must_use]
-    pub fn dpad_y_buttons() -> Self {
+    pub fn up_down_dpad() -> Self {
         Self {
             positive: GamepadButton::DPadUp.into(),
             negative: GamepadButton::DPadDown.into(),

--- a/src/preset/cardinal.rs
+++ b/src/preset/cardinal.rs
@@ -42,7 +42,7 @@ impl Cardinal<Binding, Binding, Binding, Binding> {
 
     /// Maps keyboard arrow keys as 2-dimensional input.
     #[must_use]
-    pub fn arrow_keys() -> Self {
+    pub fn arrows() -> Self {
         Self {
             north: KeyCode::ArrowUp.into(),
             west: KeyCode::ArrowLeft.into(),
@@ -55,7 +55,7 @@ impl Cardinal<Binding, Binding, Binding, Binding> {
 impl Cardinal<Binding, Binding, Binding, Binding> {
     /// Maps D-pad as 2-dimensional input.
     #[must_use]
-    pub fn dpad_buttons() -> Self {
+    pub fn dpad() -> Self {
         Self {
             north: GamepadButton::DPadUp.into(),
             west: GamepadButton::DPadLeft.into(),

--- a/src/preset/ordinal.rs
+++ b/src/preset/ordinal.rs
@@ -35,7 +35,7 @@ impl<N, NE, E, SE, S, SW, W, NW, T: Clone> WithBundle<T> for Ordinal<N, NE, E, S
 impl Ordinal<Binding, Binding, Binding, Binding, Binding, Binding, Binding, Binding> {
     /// Maps numpad keys as 2-dimensional input.
     #[must_use]
-    pub fn numpad_keys() -> Self {
+    pub fn numpad() -> Self {
         Self {
             north: KeyCode::Numpad8.into(),
             north_east: KeyCode::Numpad9.into(),

--- a/tests/preset.rs
+++ b/tests/preset.rs
@@ -16,7 +16,7 @@ fn keys() {
                 Action::<Test>::new(),
                 Bindings::spawn((
                     Cardinal::wasd_keys(),
-                    Cardinal::arrow_keys(),
+                    Cardinal::arrows(),
                     Bidirectional {
                         positive: Binding::from(KeyCode::NumpadAdd),
                         negative: Binding::from(KeyCode::NumpadSubtract),
@@ -30,7 +30,7 @@ fn keys() {
                         down: Binding::from(KeyCode::Digit5),
                     },
                     Ordinal::hjklyubn_keys(),
-                    Ordinal::numpad_keys(),
+                    Ordinal::numpad(),
                 ))
             )]
         ),
@@ -101,12 +101,7 @@ fn dpad() {
     app.world_mut().spawn((
         TestContext,
         GamepadDevice::Single(gamepad_entity),
-        actions!(
-            TestContext[(
-                Action::<Test>::new(),
-                Bindings::spawn(Cardinal::dpad_buttons())
-            )]
-        ),
+        actions!(TestContext[(Action::<Test>::new(), Bindings::spawn(Cardinal::dpad()))]),
     ));
 
     app.update();


### PR DESCRIPTION
`horizontal_arrow_keys` and `vertical_arrow_keys` are quite long.