### PR TITLE
Add PartialEq on Action<A>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `bindings!` now properly works with trailing commas and no longer requires wrapping single elements in braces when mixed with tuples.
 - `Clone`, `PartialEq`, `Eq` and `Debug` are implemented for `ActionOf<C>` even if `C` doesn't implement them.
+- `InputAction` now requires `PartialEq`, and `Action<A>` implements `PartialEq`.
 
 ### Removed
 

--- a/src/action.rs
+++ b/src/action.rs
@@ -91,6 +91,12 @@ impl<A: InputAction> Default for Action<A> {
     }
 }
 
+impl<A: InputAction> PartialEq for Action<A> {
+    fn eq(&self, other: &Self) -> bool {
+        **self == **other
+    }
+}
+
 impl<A: InputAction> Action<A> {
     pub fn new() -> Self {
         Self::default()
@@ -121,7 +127,9 @@ pub trait InputAction: 'static {
 }
 
 /// Type which can be used as [`InputAction::Output`].
-pub trait ActionOutput: Into<ActionValue> + Default + Send + Sync + Debug + Clone + Copy {
+pub trait ActionOutput:
+    Into<ActionValue> + Default + Send + Sync + Debug + Clone + Copy + PartialEq
+{
     /// Dimension of this output.
     ///
     /// Used for [`ActionValue`] initialization.


### PR DESCRIPTION
It would be easier for me to network `Action<A>` if it implemented PartialEq.

(in theory it's not exactly required, since i'm just networking the component id because I don't care about the actual value. I do need to network this component since it requires all the other components)

I do think that this bound is in general useful to be able to compare ActionValues