### PR TITLE
Don't trigger change detection on `Actions<C>` due to sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `bindings!` now properly works with trailing commas and no longer requires wrapping single elements in braces when mixed with tuples.
 - `Clone`, `PartialEq`, `Eq` and `Debug` are implemented for `ActionOf<C>` even if `C` doesn't implement them.
+- Don't trigger change detection on `Actions<C>` due to sorting.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `bindings!` now properly works with trailing commas and no longer requires wrapping single elements in braces when mixed with tuples.
 - `Clone`, `PartialEq`, `Eq` and `Debug` are implemented for `ActionOf<C>` even if `C` doesn't implement them.
-- Don't trigger change detection on `Actions<C>` due to sorting.
+- Don't trigger change detection on `Actions<C>` on sorting if it's already sorted.
 
 ### Removed
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -302,10 +302,8 @@ fn update<S: ScheduleLabel>(
             continue;
         };
 
-        // We only sort actions, without actually modifying elements the collection.
-        let context_actions = context_actions.bypass_change_detection();
-        context_actions.sort_by_cached_key(|&action| {
-            let Ok((.., action_bindings, _, _, _)) = actions.get(action) else {
+        let mods_count = |action: &Entity| {
+            let Ok((.., action_bindings, _, _, _)) = actions.get(*action) else {
                 // TODO: use `warn_once` when `bevy_log` becomes `no_std` compatible.
                 warn!(
                     "`{action}` from `{}` missing action components",
@@ -320,7 +318,11 @@ fn update<S: ScheduleLabel>(
                 .max()
                 .unwrap_or(0);
             Reverse(value)
-        });
+        };
+
+        if !context_actions.is_sorted_by_key(mods_count) {
+            context_actions.sort_by_cached_key(mods_count);
+        }
 
         trace!("updating `{}` on `{}`", instance.name, instance.entity);
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -302,7 +302,7 @@ fn update<S: ScheduleLabel>(
             continue;
         };
 
-        // We only sort actions, without actually modifying the collection.
+        // We only sort actions, without actually modifying elements the collection.
         let context_actions = context_actions.bypass_change_detection();
         context_actions.sort_by_cached_key(|&action| {
             let Ok((.., action_bindings, _, _, _)) = actions.get(action) else {

--- a/src/context.rs
+++ b/src/context.rs
@@ -298,10 +298,12 @@ fn update<S: ScheduleLabel>(
         };
 
         let gamepad = context.get::<GamepadDevice>().copied().unwrap_or_default();
-        let Some(context_actions) = instance.actions_mut(&mut context) else {
+        let Some(mut context_actions) = instance.actions_mut(&mut context) else {
             continue;
         };
 
+        // We only sort actions, without actually modifying the collection.
+        let context_actions = context_actions.bypass_change_detection();
         context_actions.sort_by_cached_key(|&action| {
             let Ok((.., action_bindings, _, _, _)) = actions.get(action) else {
                 // TODO: use `warn_once` when `bevy_log` becomes `no_std` compatible.
@@ -324,7 +326,7 @@ fn update<S: ScheduleLabel>(
 
         reader.set_gamepad(gamepad);
 
-        let mut actions_iter = actions.iter_many_mut(context_actions);
+        let mut actions_iter = actions.iter_many_mut(&*context_actions);
         while let Some((
             action,
             action_name,

--- a/src/context/instance.rs
+++ b/src/context/instance.rs
@@ -58,7 +58,7 @@ pub(crate) struct ContextInstance {
     type_id: TypeId,
     priority: usize,
     actions: for<'a> fn(&Self, &'a FilteredEntityRef) -> Option<&'a [Entity]>,
-    actions_mut: for<'a> fn(&Self, &'a mut FilteredEntityMut) -> Option<&'a mut [Entity]>,
+    actions_mut: for<'a> fn(&Self, &'a mut FilteredEntityMut) -> Option<Mut<'a, [Entity]>>,
 }
 
 impl ContextInstance {
@@ -86,7 +86,7 @@ impl ContextInstance {
     pub(super) fn actions_mut<'a>(
         &self,
         context: &'a mut FilteredEntityMut,
-    ) -> Option<&'a mut [Entity]> {
+    ) -> Option<Mut<'a, [Entity]>> {
         (self.actions_mut)(self, context)
     }
 
@@ -100,9 +100,9 @@ impl ContextInstance {
     fn actions_mut_typed<'a, C: Component>(
         &self,
         context: &'a mut FilteredEntityMut,
-    ) -> Option<&'a mut [Entity]> {
+    ) -> Option<Mut<'a, [Entity]>> {
         context
             .get_mut::<Actions<C>>()
-            .map(|actions| &mut **actions.into_inner().collection_mut_risky())
+            .map(|a| a.map_unchanged(|a| &mut **a.collection_mut_risky()))
     }
 }


### PR DESCRIPTION
We sort actions based on their number of modifiers. There is no reliable way to detect whether sorting is needed, because bindings on actions can technically not only be inserted but also reparented.

So we sort them every time. Sorting in Rust is already optimized for unchanged collections. However, this triggers change detection every frame. Since users usually expect a relationship target to change only when its elements actually change, I bypassed the change detection as a workaround.