### PR TITLE
Add `action` to events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Target context entity on events triggered by action removals.
+
 ## [0.16.0] - 2025-08-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- All events now include an `action` field with the entity of the action that triggered them.
+
 ### Fixed
 
 - Target context entity on events triggered by action removals.

--- a/src/action.rs
+++ b/src/action.rs
@@ -6,55 +6,10 @@ pub mod value;
 use core::{any, fmt::Debug, time::Duration};
 
 use bevy::prelude::*;
-use log::trace;
 use serde::{Deserialize, Serialize};
 
-use crate::{context::input_reader::PendingBindings, prelude::*};
+use crate::prelude::*;
 use fns::ActionFns;
-
-/// Resets action data and triggers corresponding events on removal.
-pub(crate) fn remove_action(
-    trigger: Trigger<OnRemove, ActionValue>,
-    mut commands: Commands,
-    mut pending: ResMut<PendingBindings>,
-    mut actions: Query<(
-        Option<&Bindings>,
-        &ActionSettings,
-        &ActionFns,
-        &mut ActionValue,
-        &mut ActionState,
-        &mut ActionEvents,
-        &mut ActionTime,
-    )>,
-    bindings: Query<&Binding>,
-) {
-    let Ok((action_bindings, settings, fns, mut value, mut state, mut events, mut time)) =
-        actions.get_mut(trigger.target())
-    else {
-        trace!("ignoring reset for `{}`", trigger.target());
-        return;
-    };
-
-    *time = Default::default();
-    events.set_if_neq(ActionEvents::new(*state, ActionState::None));
-    state.set_if_neq(Default::default());
-    value.set_if_neq(ActionValue::zero(value.dim()));
-
-    fns.trigger(
-        &mut commands,
-        trigger.target(),
-        *state,
-        *events,
-        *value,
-        *time,
-    );
-
-    if let Some(action_bindings) = action_bindings
-        && settings.require_reset
-    {
-        pending.extend(bindings.iter_many(action_bindings).copied());
-    }
-}
 
 /// Component that represents a user action.
 ///

--- a/src/action/events.rs
+++ b/src/action/events.rs
@@ -105,6 +105,9 @@ impl ActionEvents {
 /// ```
 #[derive(Event)]
 pub struct Started<A: InputAction> {
+    /// Action that triggered this event.
+    pub action: Entity,
+
     /// Current action value.
     pub value: A::Output,
 
@@ -175,6 +178,9 @@ impl<A: InputAction> Copy for Started<A> {}
 /// ```
 #[derive(Event)]
 pub struct Ongoing<A: InputAction> {
+    /// Action that triggered this event.
+    pub action: Entity,
+
     /// Current action value.
     pub value: A::Output,
 
@@ -239,6 +245,9 @@ impl<A: InputAction> Copy for Ongoing<A> {}
 /// ```
 #[derive(Event)]
 pub struct Fired<A: InputAction> {
+    /// Action that triggered this event.
+    pub action: Entity,
+
     /// Current action value.
     pub value: A::Output,
 
@@ -312,6 +321,9 @@ impl<A: InputAction> Copy for Fired<A> {}
 /// ```
 #[derive(Event)]
 pub struct Canceled<A: InputAction> {
+    /// Action that triggered this event.
+    pub action: Entity,
+
     /// Current action value.
     pub value: A::Output,
 
@@ -403,6 +415,9 @@ impl<A: InputAction> Copy for Canceled<A> {}
 /// ```
 #[derive(Event)]
 pub struct Completed<A: InputAction> {
+    /// Action that triggered this event.
+    pub action: Entity,
+
     /// Current action value.
     pub value: A::Output,
 

--- a/src/action/fns.rs
+++ b/src/action/fns.rs
@@ -1,4 +1,4 @@
-use core::{any, fmt::Debug};
+use core::any;
 
 use bevy::prelude::*;
 use log::debug;
@@ -62,80 +62,62 @@ fn trigger<A: InputAction>(
     value: ActionValue,
     time: ActionTime,
 ) {
-    for (_, event) in events.iter_names() {
+    for (name, event) in events.iter_names() {
+        debug!(
+            "triggering `{name}` from `{}` for `{context}`",
+            any::type_name::<A>()
+        );
+
         match event {
             ActionEvents::STARTED => {
-                trigger_and_log::<A, _>(
-                    commands,
-                    context,
-                    Started::<A> {
-                        action,
-                        value: A::Output::unwrap_value(value),
-                        state,
-                    },
-                );
+                let event = Started::<A> {
+                    action,
+                    value: A::Output::unwrap_value(value),
+                    state,
+                };
+                commands.trigger_targets(event, context);
             }
             ActionEvents::ONGOING => {
-                trigger_and_log::<A, _>(
-                    commands,
-                    context,
-                    Ongoing::<A> {
-                        action,
-                        value: A::Output::unwrap_value(value),
-                        state,
-                        elapsed_secs: time.elapsed_secs,
-                    },
-                );
+                let event = Ongoing::<A> {
+                    action,
+                    value: A::Output::unwrap_value(value),
+                    state,
+                    elapsed_secs: time.elapsed_secs,
+                };
+                commands.trigger_targets(event, context);
             }
             ActionEvents::FIRED => {
-                trigger_and_log::<A, _>(
-                    commands,
-                    context,
-                    Fired::<A> {
-                        action,
-                        value: A::Output::unwrap_value(value),
-                        state,
-                        fired_secs: time.fired_secs,
-                        elapsed_secs: time.elapsed_secs,
-                    },
-                );
+                let event = Fired::<A> {
+                    action,
+                    value: A::Output::unwrap_value(value),
+                    state,
+                    fired_secs: time.fired_secs,
+                    elapsed_secs: time.elapsed_secs,
+                };
+                commands.trigger_targets(event, context);
             }
             ActionEvents::CANCELED => {
-                trigger_and_log::<A, _>(
-                    commands,
-                    context,
-                    Canceled::<A> {
-                        action,
-                        value: A::Output::unwrap_value(value),
-                        state,
-                        elapsed_secs: time.elapsed_secs,
-                    },
-                );
+                let event = Canceled::<A> {
+                    action,
+                    value: A::Output::unwrap_value(value),
+                    state,
+                    elapsed_secs: time.elapsed_secs,
+                };
+                commands.trigger_targets(event, context);
             }
             ActionEvents::COMPLETED => {
-                trigger_and_log::<A, _>(
-                    commands,
-                    context,
-                    Completed::<A> {
-                        action,
-                        value: A::Output::unwrap_value(value),
-                        state,
-                        fired_secs: time.fired_secs,
-                        elapsed_secs: time.elapsed_secs,
-                    },
-                );
+                let event = Completed::<A> {
+                    action,
+                    value: A::Output::unwrap_value(value),
+                    state,
+                    fired_secs: time.fired_secs,
+                    elapsed_secs: time.elapsed_secs,
+                };
+                commands.trigger_targets(event, context);
             }
             _ => unreachable!("iteration should yield only named flags"),
         }
     }
-}
-
-fn trigger_and_log<A, E: Event + Debug>(commands: &mut Commands, context: Entity, event: E) {
-    debug!(
-        "triggering `{event:?}` for `{}` for `{context}`",
-        any::type_name::<A>()
-    );
-    commands.trigger_targets(event, context);
 }
 
 #[cfg(test)]

--- a/src/action/fns.rs
+++ b/src/action/fns.rs
@@ -33,13 +33,13 @@ impl ActionFns {
     pub(crate) fn trigger(
         &self,
         commands: &mut Commands,
-        action: Entity,
+        context: Entity,
         state: ActionState,
         events: ActionEvents,
         value: ActionValue,
         time: ActionTime,
     ) {
-        (self.trigger)(commands, action, state, events, value, time);
+        (self.trigger)(commands, context, state, events, value, time);
     }
 }
 
@@ -53,7 +53,7 @@ fn store_value<A: InputAction>(action: &mut EntityMut, value: ActionValue) {
 
 fn trigger<A: InputAction>(
     commands: &mut Commands,
-    action: Entity,
+    context: Entity,
     state: ActionState,
     events: ActionEvents,
     value: ActionValue,
@@ -64,7 +64,7 @@ fn trigger<A: InputAction>(
             ActionEvents::STARTED => {
                 trigger_and_log::<A, _>(
                     commands,
-                    action,
+                    context,
                     Started::<A> {
                         value: A::Output::unwrap_value(value),
                         state,
@@ -74,7 +74,7 @@ fn trigger<A: InputAction>(
             ActionEvents::ONGOING => {
                 trigger_and_log::<A, _>(
                     commands,
-                    action,
+                    context,
                     Ongoing::<A> {
                         value: A::Output::unwrap_value(value),
                         state,
@@ -85,7 +85,7 @@ fn trigger<A: InputAction>(
             ActionEvents::FIRED => {
                 trigger_and_log::<A, _>(
                     commands,
-                    action,
+                    context,
                     Fired::<A> {
                         value: A::Output::unwrap_value(value),
                         state,
@@ -97,7 +97,7 @@ fn trigger<A: InputAction>(
             ActionEvents::CANCELED => {
                 trigger_and_log::<A, _>(
                     commands,
-                    action,
+                    context,
                     Canceled::<A> {
                         value: A::Output::unwrap_value(value),
                         state,
@@ -108,7 +108,7 @@ fn trigger<A: InputAction>(
             ActionEvents::COMPLETED => {
                 trigger_and_log::<A, _>(
                     commands,
-                    action,
+                    context,
                     Completed::<A> {
                         value: A::Output::unwrap_value(value),
                         state,
@@ -122,12 +122,12 @@ fn trigger<A: InputAction>(
     }
 }
 
-fn trigger_and_log<A, E: Event + Debug>(commands: &mut Commands, action: Entity, event: E) {
+fn trigger_and_log<A, E: Event + Debug>(commands: &mut Commands, context: Entity, event: E) {
     debug!(
-        "triggering `{event:?}` for `{}` for `{action}`",
+        "triggering `{event:?}` for `{}` for `{context}`",
         any::type_name::<A>()
     );
-    commands.trigger_targets(event, action);
+    commands.trigger_targets(event, context);
 }
 
 #[cfg(test)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -323,7 +323,15 @@ pub(crate) fn reset_action<C: Component>(
     state.set_if_neq(Default::default());
     value.set_if_neq(ActionValue::zero(value.dim()));
 
-    fns.trigger(&mut commands, **action_of, *state, *events, *value, *time);
+    fns.trigger(
+        &mut commands,
+        **action_of,
+        trigger.target(),
+        *state,
+        *events,
+        *value,
+        *time,
+    );
 
     if let Some(action_bindings) = action_bindings
         && settings.require_reset
@@ -602,7 +610,15 @@ fn apply<S: ScheduleLabel>(
             let state = *action.get::<ActionState>().unwrap();
             let events = *action.get::<ActionEvents>().unwrap();
             let time = *action.get::<ActionTime>().unwrap();
-            fns.trigger(&mut commands, context.id(), state, events, value, time);
+            fns.trigger(
+                &mut commands,
+                context.id(),
+                action.id(),
+                state,
+                events,
+                value,
+                time,
+            );
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -505,7 +505,6 @@ impl Plugin for EnhancedInputPlugin {
                     .chain()
                     .after(InputSystem),
             )
-            .add_observer(action::remove_action)
             .add_systems(
                 PreUpdate,
                 input_reader::update_pending.in_set(EnhancedInputSet::Prepare),


### PR DESCRIPTION
All actions target an entity with a context. This makes sense, since users can attach an input context to their player and react to actions in a convenient way.
However, sometimes it is useful to know which action entity triggered the event - especially if you have multiple identical actions with different bindings.
