### PR TITLE
Make ActionTime pub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Made `ActionTime::update` public
+
 ## [0.18.0] - 2025-08-26
 
 ### Added

--- a/src/action.rs
+++ b/src/action.rs
@@ -259,7 +259,7 @@ pub struct ActionTime {
 }
 
 impl ActionTime {
-    pub(crate) fn update(&mut self, delta_secs: f32, state: ActionState) {
+    pub fn update(&mut self, delta_secs: f32, state: ActionState) {
         match state {
             ActionState::None => {
                 self.elapsed_secs = 0.0;

--- a/src/action.rs
+++ b/src/action.rs
@@ -259,6 +259,8 @@ pub struct ActionTime {
 }
 
 impl ActionTime {
+
+    /// Updates the timers based on the given delta time and action state.
     pub fn update(&mut self, delta_secs: f32, state: ActionState) {
         match state {
             ActionState::None => {

--- a/src/action.rs
+++ b/src/action.rs
@@ -259,7 +259,6 @@ pub struct ActionTime {
 }
 
 impl ActionTime {
-
     /// Updates the timers based on the given delta time and action state.
     pub fn update(&mut self, delta_secs: f32, state: ActionState) {
         match state {


### PR DESCRIPTION
For input prediction purposes, I need this method to be public.

The reason is that:
- on client I am on tick 9
- I have received the inputs from another client for tick 5
- To correctly predict the actions of the other client, currently I act as if the remote client keeps triggering the same actions. So I predict that on ticks 6, 7, 8, 9 the ActionValue, ActionState, ActionEvents are the same. However I need to update the ActionTime correctly.

Let me know if this makes sense. It's a pretty ad-hoc approach, ideally the ActionState/ActionEvents would also be updated correctly (for example I wouldn't want to predict that a rare event is emitted every tick)