### PR TITLE
Add ExternallyMocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a component `ExcludeFromUpdate` to exclude actions from being updated.
+
 ### Changed
 
 - Made `ActionTime::update` public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added a component `ExcludeFromUpdate` to exclude actions from being updated.
+- Added a component `ExternallyMocked` to exclude actions from being updated. These actions are updated manually by the user.
 
 ### Changed
 

--- a/src/action.rs
+++ b/src/action.rs
@@ -291,6 +291,8 @@ impl ActionTime {
 /// Mocking does not take effect immediately - it is applied during the next context evaluation.
 /// For more details, see the [evaluation](../index.html#evaluation) section in the quick start guide.
 ///
+/// See also [`ExternallyMocked`](crate::context::ExternallyMocked) to manually control the action data.
+///
 /// # Examples
 ///
 /// Spawn and move up for 2 seconds:

--- a/src/context.rs
+++ b/src/context.rs
@@ -180,7 +180,6 @@ impl ScheduleContexts {
             QueryParamBuilder::new(|builder| {
                 builder
                     .data::<Option<&GamepadDevice>>()
-                    .without::<ExternallyMocked>()
                     .optional(|builder| {
                         for &id in &self.activity_ids {
                             builder.mut_id(id);
@@ -194,7 +193,7 @@ impl ScheduleContexts {
             ParamBuilder,
             ParamBuilder,
             QueryParamBuilder::new(|builder| {
-                builder.without::<ExternallyMocked>().optional(|builder| {
+                builder.optional(|builder| {
                     for &id in &**conditions {
                         builder.mut_id(id);
                     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -194,9 +194,7 @@ impl ScheduleContexts {
             ParamBuilder,
             ParamBuilder,
             QueryParamBuilder::new(|builder| {
-                builder
-                    .without::<ExternallyMocked>()
-                    .optional(|builder| {
+                builder.without::<ExternallyMocked>().optional(|builder| {
                     for &id in &**conditions {
                         builder.mut_id(id);
                     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -340,11 +340,11 @@ pub(crate) fn reset_action<C: Component>(
     }
 }
 
-/// Marker component that can be used to exclude some [`Action`] entities from the `update` system.
+/// Marks an [`Action<C>`] as manually mocked, skipping the [`EnhancedInputSet::Update`] logic for it.
 ///
-/// This is useful if the user wants greater control over how the [`Action`]'s components are updated.
+/// This allows modifying any action data without its values being overridden during evaluation.
 ///
-/// This is an advanced feature that should be used with caution.
+/// Takes precedence over [`ActionMock`], which drives specific [`ActionValue`] and [`ActionState`] during evaluation.
 #[derive(Component)]
 pub struct ExternallyMocked;
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -340,9 +340,13 @@ pub(crate) fn reset_action<C: Component>(
     }
 }
 
-/// Marker component that can be used to exclude some Action entities from the [`update`] system.
+/// Marker component that can be used to exclude some [`Action`] entities from the [`update`] system.
+///
+/// This is useful if the user wants greater control over how the [`Action`]'s components are updated.
+///
+/// This is an advanced feature that should be used with caution.
 #[derive(Component)]
-pub struct ExcludeFromUpdate;
+pub struct ExternallyMocked;
 
 #[allow(clippy::too_many_arguments)]
 fn update<S: ScheduleLabel>(
@@ -361,7 +365,7 @@ fn update<S: ScheduleLabel>(
             Option<&ConditionFns>,
             Option<&mut ActionMock>,
         ),
-        Without<ExcludeFromUpdate>,
+        Without<ExternallyMocked>,
     >,
     mut actions_data: Query<(
         &'static mut ActionValue,

--- a/src/context.rs
+++ b/src/context.rs
@@ -180,6 +180,7 @@ impl ScheduleContexts {
             QueryParamBuilder::new(|builder| {
                 builder
                     .data::<Option<&GamepadDevice>>()
+                    .without::<ExternallyMocked>()
                     .optional(|builder| {
                         for &id in &self.activity_ids {
                             builder.mut_id(id);
@@ -193,7 +194,9 @@ impl ScheduleContexts {
             ParamBuilder,
             ParamBuilder,
             QueryParamBuilder::new(|builder| {
-                builder.optional(|builder| {
+                builder
+                    .without::<ExternallyMocked>()
+                    .optional(|builder| {
                     for &id in &**conditions {
                         builder.mut_id(id);
                     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -21,7 +21,7 @@ use bevy::{
     },
     prelude::*,
 };
-use log::{debug, trace, warn};
+use log::{debug, trace};
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/src/context.rs
+++ b/src/context.rs
@@ -340,7 +340,7 @@ pub(crate) fn reset_action<C: Component>(
     }
 }
 
-/// Marker component that can be used to exclude some [`Action`] entities from the [`update`] system.
+/// Marker component that can be used to exclude some [`Action`] entities from the `update` system.
 ///
 /// This is useful if the user wants greater control over how the [`Action`]'s components are updated.
 ///

--- a/src/context.rs
+++ b/src/context.rs
@@ -404,11 +404,6 @@ fn update<S: ScheduleLabel>(
 
         let mods_count = |action: &Entity| {
             let Ok((.., action_bindings, _, _, _)) = actions.get(*action) else {
-                // TODO: use `warn_once` when `bevy_log` becomes `no_std` compatible.
-                warn!(
-                    "`{action}` from `{}` missing action components",
-                    instance.name
-                );
                 return Reverse(0);
             };
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -340,6 +340,10 @@ pub(crate) fn reset_action<C: Component>(
     }
 }
 
+/// Marker component that can be used to exclude some Action entities from the [`update`] system.
+#[derive(Component)]
+pub struct ExcludeFromUpdate;
+
 #[allow(clippy::too_many_arguments)]
 fn update<S: ScheduleLabel>(
     mut consume_buffer: Local<Vec<Binding>>, // Consumed inputs during state evaluation.
@@ -347,15 +351,18 @@ fn update<S: ScheduleLabel>(
     mut reader: InputReader,
     instances: Res<ContextInstances<S>>,
     mut contexts: Query<FilteredEntityMut>,
-    mut actions: Query<(
-        Entity,
-        &Name,
-        &ActionSettings,
-        Option<&Bindings>,
-        Option<&ModifierFns>,
-        Option<&ConditionFns>,
-        Option<&mut ActionMock>,
-    )>,
+    mut actions: Query<
+        (
+            Entity,
+            &Name,
+            &ActionSettings,
+            Option<&Bindings>,
+            Option<&ModifierFns>,
+            Option<&ConditionFns>,
+            Option<&mut ActionMock>,
+        ),
+        Without<ExcludeFromUpdate>,
+    >,
     mut actions_data: Query<(
         &'static mut ActionValue,
         &'static mut ActionState,

--- a/tests/mocking.rs
+++ b/tests/mocking.rs
@@ -1,8 +1,7 @@
 use core::time::Duration;
 
 use bevy::{prelude::*, time::TimeUpdateStrategy};
-use bevy_enhanced_input::context::ExternallyMocked;
-use bevy_enhanced_input::prelude::*;
+use bevy_enhanced_input::{context::ExternallyMocked, prelude::*};
 use test_log::test;
 
 #[test]

--- a/tests/mocking.rs
+++ b/tests/mocking.rs
@@ -157,9 +157,11 @@ fn external_mock() {
         .world_mut()
         .query::<(&Action<Test>, &ActionState, &ActionEvents)>();
 
-    // the action data should not be updated because of ExternallyMocked
     let (&action, &state, &events) = actions.single(app.world()).unwrap();
-    assert!(!*action);
+    assert!(
+        !*action,
+        "action shouldn't be updated because it marked as mocked externally"
+    );
     assert_eq!(state, ActionState::None);
     assert_eq!(events, ActionEvents::empty());
 }


### PR DESCRIPTION
In niche situations (networking), it is useful to be able to opt-out of running `BEI::Update` for some Action entities.

For example if we want to predict the actions of remote clients, we receive from the Server regular messages that give us information about the ActionState for these other clients.

For these remote clients, we don't want to run BEI::Update but instead we want to have greater control over how they are updated:
- their state could be pulled from an input buffer if we have that available
- or we could decay their action slightly if we don't have any ticks available


An alternative could be to set an ActionMock on these remote entities, but that's not efficient because it would require running BEI::Update during rollbacks so that the ActionMock can update the ActionTime/ActionEvents components.
Therefore we provide an escape hatch called `ExternallyMocked` to indicate that the client has control over how the components of that Action are updated.