### PR TITLE
Fix DuplicateRegistration

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -102,6 +102,7 @@ impl InputContextAppExt for App {
 
         let _ = self.try_register_required_components::<C, ContextPriority<C>>();
         let _ = self.try_register_required_components::<C, ContextActivity<C>>();
+
         self.add_observer(register::<C, S>)
             .add_observer(unregister::<C, S>)
             .add_observer(reset_action::<C>)

--- a/src/context.rs
+++ b/src/context.rs
@@ -100,9 +100,9 @@ impl InputContextAppExt for App {
             registry.push(contexts);
         }
 
-        self.register_required_components::<C, ContextPriority<C>>()
-            .register_required_components::<C, ContextActivity<C>>()
-            .add_observer(register::<C, S>)
+        let _ = self.try_register_required_components::<C, ContextPriority<C>>();
+        let _ = self.try_register_required_components::<C, ContextActivity<C>>();
+        self.add_observer(register::<C, S>)
             .add_observer(unregister::<C, S>)
             .add_observer(reset_action::<C>)
             .add_observer(deactivate::<C>);


### PR DESCRIPTION
Fix DuplicateRegistration when `ContextActivity<C>` is the require component of `Actions<C>`.

bevy_enhanced_input currently supports the following usage.

```rust
#[derive(Component, Default)]
#[require(ContextActivity::<Self>::INACTIVE)]
pub(crate) struct Input;
```