### PR TITLE
Dont panic on dim missmatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.19.0-rc.1] - 2025-09-24
 
+### Added
+
+- `From` impl to primitive types for `ActionValue`.
+
 ### Changed
 
 - Update to Bevy 0.17.0-rc.1.
@@ -23,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Note that `Press`, `Release`, and `Cancel` collide with names from `bevy_picking` and present in both `bevy::prelude::*` and `bevy_enhanced_input::prelude::*`.
   To disambiguate, import `bevy_enhanced_input::prelude::{*, Press, Release, Cancel}`.
 - Serde integration is now gated behind the `serialize` feature.
+- Warn on dimension mismatch instead of panicking.
+
+### Fixed
+
+- `ActionOutput::unwrap_value`.
 
 ## [0.18.2] - 2025-09-10
 

--- a/src/action.rs
+++ b/src/action.rs
@@ -84,65 +84,28 @@ pub trait InputAction: 'static {
 
 /// Type which can be used as [`InputAction::Output`].
 pub trait ActionOutput:
-    Into<ActionValue> + Default + Send + Sync + Debug + Clone + Copy + PartialEq
+    From<ActionValue> + Default + Send + Sync + Debug + Clone + Copy + PartialEq
 {
     /// Dimension of this output.
     ///
     /// Used for [`ActionValue`] initialization.
     const DIM: ActionValueDim;
-
-    /// Converts the value into the action output type.
-    ///
-    /// Used to write the value into [`Action<C>`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if the value represents a different type.
-    fn unwrap_value(value: ActionValue) -> Self;
 }
 
 impl ActionOutput for bool {
     const DIM: ActionValueDim = ActionValueDim::Bool;
-
-    fn unwrap_value(value: ActionValue) -> Self {
-        let ActionValue::Bool(value) = value else {
-            panic!("output value should be bool");
-        };
-        value
-    }
 }
 
 impl ActionOutput for f32 {
     const DIM: ActionValueDim = ActionValueDim::Axis1D;
-
-    fn unwrap_value(value: ActionValue) -> Self {
-        let ActionValue::Axis1D(value) = value else {
-            panic!("output value should be axis 1D");
-        };
-        value
-    }
 }
 
 impl ActionOutput for Vec2 {
     const DIM: ActionValueDim = ActionValueDim::Axis2D;
-
-    fn unwrap_value(value: ActionValue) -> Self {
-        let ActionValue::Axis2D(value) = value else {
-            panic!("output value should be axis 2D");
-        };
-        value
-    }
 }
 
 impl ActionOutput for Vec3 {
     const DIM: ActionValueDim = ActionValueDim::Axis3D;
-
-    fn unwrap_value(value: ActionValue) -> Self {
-        let ActionValue::Axis3D(value) = value else {
-            panic!("output value should be axis 3D");
-        };
-        value
-    }
 }
 
 /// Behavior configuration for [`Action<C>`].

--- a/src/action/value.rs
+++ b/src/action/value.rs
@@ -185,6 +185,30 @@ impl From<(f32, f32, f32)> for ActionValue {
     }
 }
 
+impl From<ActionValue> for bool {
+    fn from(value: ActionValue) -> Self {
+        value.as_bool()
+    }
+}
+
+impl From<ActionValue> for f32 {
+    fn from(value: ActionValue) -> Self {
+        value.as_axis1d()
+    }
+}
+
+impl From<ActionValue> for Vec2 {
+    fn from(value: ActionValue) -> Self {
+        value.as_axis2d()
+    }
+}
+
+impl From<ActionValue> for Vec3 {
+    fn from(value: ActionValue) -> Self {
+        value.as_axis3d()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
I used `panic!` because users couldn't trigger it. But since we split update and triggering for networking, it's now possible to cause this panic for advanced users. Since we can recover gracefully, let's avoid panicking.