### PR TITLE
Split EnhancedInputSystems::Apply into Apply and Trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Split `EnhancedInputSystems::Apply` into two sets: `Apply` (where `Action` gets updated) and `Trigger` (where observers get triggered)
+
 ## [0.26.0] - 2026-06-20
 
 ### Changed

--- a/src/action/events.rs
+++ b/src/action/events.rs
@@ -9,7 +9,7 @@ use crate::prelude::*;
 
 /// Bitset with events caused by state transitions of [`TriggerState`].
 ///
-/// During [`EnhancedInputSystems::Apply`], events that correspond to bitflags will be triggered.
+/// During [`EnhancedInputSystems::Trigger`], events that correspond to bitflags will be triggered.
 ///
 /// You can use this component directly in systems or react on corresponding events in observers.
 ///

--- a/src/context.rs
+++ b/src/context.rs
@@ -280,14 +280,10 @@ impl ScheduleContexts {
             .build_state(app.world_mut())
             .build_system(update::<S>);
 
-        let trigger_fn = (
-            ParamBuilder,
+        let apply_fn = (
             ParamBuilder,
             QueryParamBuilder::new(|builder| {
                 builder.optional(|builder| {
-                    for &id in &self.activity_ids {
-                        builder.mut_id(id);
-                    }
                     for &id in &self.actions_ids {
                         builder.ref_id(id);
                     }
@@ -298,16 +294,37 @@ impl ScheduleContexts {
             .build_state(app.world_mut())
             .build_system(apply::<S>);
 
+        let trigger_fn = (
+            ParamBuilder,
+            ParamBuilder,
+            QueryParamBuilder::new(|builder| {
+                builder.optional(|builder| {
+                    for &id in &self.actions_ids {
+                        builder.ref_id(id);
+                    }
+                });
+            }),
+            ParamBuilder,
+        )
+            .build_state(app.world_mut())
+            .build_system(trigger::<S>);
+
         app.init_resource::<ContextInstances<S>>()
             .configure_sets(
                 S::default(),
-                (EnhancedInputSystems::Update, EnhancedInputSystems::Apply).chain(),
+                (
+                    EnhancedInputSystems::Update,
+                    EnhancedInputSystems::Apply,
+                    EnhancedInputSystems::Trigger,
+                )
+                    .chain(),
             )
             .add_systems(
                 S::default(),
                 (
                     update_fn.in_set(EnhancedInputSystems::Update),
-                    trigger_fn.in_set(EnhancedInputSystems::Apply),
+                    apply_fn.in_set(EnhancedInputSystems::Apply),
+                    trigger_fn.in_set(EnhancedInputSystems::Trigger),
                 ),
             );
     }
@@ -662,10 +679,43 @@ pub type ActionsQuery<'w, 's> = Query<
 >;
 
 fn apply<S: ScheduleLabel>(
-    mut commands: Commands,
     instances: Res<ContextInstances<S>>,
     contexts: Query<FilteredEntityRef, Without<ActionFns>>,
     mut actions: Query<EntityMut, (With<ActionFns>, Without<ContextInstances<S>>)>,
+) {
+    for instance in &**instances {
+        let Ok(context) = contexts.get(instance.entity()) else {
+            trace!(
+                "skipping applying values for `{}` on disabled `{}`",
+                instance.name(),
+                instance.entity(),
+            );
+            continue;
+        };
+        let Some(context_actions) = instance.actions(&context) else {
+            continue;
+        };
+
+        trace!(
+            "applying values for `{}` on `{}`",
+            instance.name(),
+            instance.entity(),
+        );
+
+        let mut actions_iter = actions.iter_many_mut(context_actions);
+        while let Some(mut action) = actions_iter.fetch_next() {
+            let fns = *action.get::<ActionFns>().unwrap();
+            let value = *action.get::<ActionValue>().unwrap();
+            fns.store_value(&mut action, value);
+        }
+    }
+}
+
+fn trigger<S: ScheduleLabel>(
+    mut commands: Commands,
+    instances: Res<ContextInstances<S>>,
+    contexts: Query<FilteredEntityRef, Without<ActionFns>>,
+    actions: Query<EntityRef, (With<ActionFns>, Without<ContextInstances<S>>)>,
 ) {
     for instance in &**instances {
         let Ok(context) = contexts.get(instance.entity()) else {
@@ -686,12 +736,9 @@ fn apply<S: ScheduleLabel>(
             instance.entity(),
         );
 
-        let mut actions_iter = actions.iter_many_mut(context_actions);
-        while let Some(mut action) = actions_iter.fetch_next() {
+        for action in actions.iter_many(context_actions) {
             let fns = *action.get::<ActionFns>().unwrap();
             let value = *action.get::<ActionValue>().unwrap();
-            fns.store_value(&mut action, value);
-
             let state = *action.get::<TriggerState>().unwrap();
             let events = *action.get::<ActionEvents>().unwrap();
             let time = *action.get::<ActionTime>().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,7 +174,7 @@ with performance playing a relatively minor role unless you have a very large nu
 
 When an action is triggered, we can notify your game logic using Bevy's [`Event`] system.
 These triggers are driven by changes (including transitions from a state to itself) in the action's [`TriggerState`],
-updated during [`EnhancedInputSystems::Apply`].
+updated during [`EnhancedInputSystems::Update`] and triggered during [`EnhancedInputSystems::Trigger`].
 
 There are a number of different [action events](crate::action::events), but the most commonly used are:
 - [`Start<A>`]: The action has started triggering (e.g. button pressed).
@@ -489,13 +489,19 @@ pub enum EnhancedInputSystems {
     ///
     /// Runs in [`PreUpdate`].
     Prepare,
-    /// Updates the state of the input contexts from inputs and mocks.
+    /// Evaluates registered input contexts from the current inputs and mocks.
+    ///
+    /// Updates [`ActionValue`], [`TriggerState`], [`ActionEvents`], and [`ActionTime`]
+    /// on each action entity.
     ///
     /// Executes in every schedule where a context is registered.
     Update,
-    /// Applies the value from [`ActionValue`] to [`Action`] and triggers
-    /// events evaluated from [`Self::Update`].
+    /// Applies the [`ActionValue`] produced by [`Self::Update`] to the typed [`Action`].
     ///
     /// Executes in every schedule where a context is registered.
     Apply,
+    /// Triggers action events evaluated by [`Self::Update`].
+    ///
+    /// Executes in every schedule where a context is registered.
+    Trigger,
 }


### PR DESCRIPTION
This allows users to order systems that read `Action<C>` before action observers